### PR TITLE
Argument to control number of operations -o no longer valid

### DIFF
--- a/source4/torture/man/smbtorture.1.xml
+++ b/source4/torture/man/smbtorture.1.xml
@@ -26,7 +26,6 @@
 		<arg choice="opt">-N numprocs</arg>
 		<arg choice="opt">-n netbios_name</arg>
 		<arg choice="opt">-W workgroup</arg>
-		<arg choice="opt">-o num_operations</arg>
 		<arg choice="opt">-e num files(entries)</arg>
 		<arg choice="opt">-O socket_options</arg>
 		<arg choice="opt">-m maximum_protocol</arg>
@@ -215,10 +214,6 @@
 
 		<varlistentry><term>-N numprocs</term>
 			<listitem><para>Specify number of smbtorture processes to launch.</para></listitem>
-		</varlistentry>
-
-		<varlistentry><term>-o num_operations</term>
-			<listitem><para>Number of times some operations should be tried before assuming they're output is consistent (default:100).</para></listitem>
 		</varlistentry>
 
 		<varlistentry><term>-e num_files</term>


### PR DESCRIPTION
Removed language referencing `-o` argument which appears to no longer be supported.

## Samba is moving to GitLab
The samba project is moving to GitLab, please consider opening a merge request there instead.
Instructions for setting up can be found at: https://wiki.samba.org/index.php/Samba_CI_on_gitlab
The GitLab repository can be found here: https://gitlab.com/samba-team/samba
